### PR TITLE
Fixing a minor bug:

### DIFF
--- a/.github/workflows/precizer.yml
+++ b/.github/workflows/precizer.yml
@@ -38,7 +38,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           gh release create ${{ github.ref_name }} precizer.zip \
-            --title "Release ${{ github.ref_name }}" \
+            --title "v${{ github.ref_name }}" \
             --notes "${{ env.BODY }}" \
             --draft
-

--- a/src/db_validate_paths.c
+++ b/src/db_validate_paths.c
@@ -195,80 +195,86 @@ Return db_validate_paths(void)
 
 	if(SUCCESS == status)
 	{
-		if(paths_are_equal == true)
+		/* If the database was just created */
+		if(config->db_file_exists == false && config->compare == false)
 		{
-			slog(TRACE,"The paths written against the database and the paths passed as arguments are completely identical\n");
+			slog(TRACE,"The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments\n");
+			provide(status);
+
 		} else {
-			slog(EVERY,"The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!\n");
 
-			if(!(rational_logger_mode & SILENT))
+			if(paths_are_equal == true)
 			{
-				slog(EVERY,"Paths saved in the database: ");
+				slog(TRACE,"The paths written against the database and the paths passed as arguments are completely identical\n");
+			} else {
+				slog(EVERY,"The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!\n");
 
-				sqlite3_stmt *stmt;
-				int rc_stmt = 0;
-				char const *sql = "SELECT prefix FROM paths;";
-
-				rc_stmt = sqlite3_prepare_v2(config->db,sql,-1,&stmt,NULL);
-
-				if(SQLITE_OK != rc_stmt)
+				if(!(rational_logger_mode & SILENT))
 				{
-					slog(ERROR,"Can't prepare select statement %s (%i): %s\n",sql,rc_stmt,sqlite3_errmsg(config->db));
-					status = FAILURE;
-				}
+					slog(EVERY,"Paths saved in the database:\n");
 
-				if(SUCCESS == status)
-				{
-					bool first_iteration = true;
+					sqlite3_stmt *stmt;
+					int rc_stmt = 0;
+					char const *sql = "SELECT prefix FROM paths;";
 
-					while(SQLITE_ROW == (rc_stmt = sqlite3_step(stmt)))
+					rc_stmt = sqlite3_prepare_v2(config->db,sql,-1,&stmt,NULL);
+
+					if(SQLITE_OK != rc_stmt)
 					{
-						const char *prefix = (const char *)sqlite3_column_text(stmt,0);
+						slog(ERROR,"Can't prepare select statement %s (%i): %s\n",sql,rc_stmt,sqlite3_errmsg(config->db));
+						status = FAILURE;
+					}
 
-						if(first_iteration == true)
+					if(SUCCESS == status)
+					{
+						while(SQLITE_ROW == (rc_stmt = sqlite3_step(stmt)))
 						{
-							printf("%s",prefix);
-							first_iteration = false;
-						} else {
-							printf(", %s",prefix);
+							const char *prefix = (const char *)sqlite3_column_text(stmt,0);
+
+							/* Truncate the file path/name in the display output if it exceeds the length limit */
+							char *path = strdup(prefix);
+
+							(void)shorten_path(path);
+
+							printf("%s\n",path);
+
+							free(path);
+						}
+
+						if(SQLITE_DONE != rc_stmt)
+						{
+							slog(ERROR,"Select statement didn't finish with DONE (%i): %s\n",rc_stmt,sqlite3_errmsg(config->db));
+							status = FAILURE;
 						}
 					}
 
-					printf("\n");
-
-					if(SQLITE_DONE != rc_stmt)
-					{
-						slog(ERROR,"Select statement didn't finish with DONE (%i): %s\n",rc_stmt,sqlite3_errmsg(config->db));
-						status = FAILURE;
-					}
+					sqlite3_finalize(stmt);
 				}
 
-				sqlite3_finalize(stmt);
-			}
-
-			if(config->force == true)
-			{
-				if(!(rational_logger_mode & SILENT))
+				if(config->force == true)
 				{
-					slog(EVERY,"The " BOLD "--force" RESET " option has been used, so the following paths will be written to the %s:\n",config->db_file_name);
-
-					for(int i = 0; config->paths[i]; i++)
+					if(!(rational_logger_mode & SILENT))
 					{
-						/* Truncate the file path/name in the display output if it exceeds the length limit */
-						char *path = strdup(config->paths[i]);
+						slog(EVERY,"The " BOLD "--force" RESET " option has been used, so the following paths will be written to the %s:\n",config->db_file_name);
 
-						(void)shorten_path(path);
+						for(int i = 0; config->paths[i]; i++)
+						{
+							/* Truncate the file path/name in the display output if it exceeds the length limit */
+							char *path = strdup(config->paths[i]);
 
-						printf("%s\n",path);
+							(void)shorten_path(path);
 
-						free(path);
+							printf("%s\n",path);
+
+							free(path);
+						}
 					}
+				} else {
+					slog(EVERY,"Use the" BOLD " --force" RESET " option only when the PATHS stored in the database need"
+						" to be updated. Warning: If this option is used incorrectly, file and checksum information"
+						" in the database may be lost or completely replaced with different values.\n");
+					status = WARNING;
 				}
-			} else {
-				slog(EVERY,"Use the" BOLD " --force" RESET " option only when the PATHS stored in the database need"
-					" to be updated. Warning: If this option is used incorrectly, file and checksum information"
-					" in the database may be lost or completely replaced with different values.\n");
-				status = WARNING;
 			}
 		}
 	}

--- a/tests/templates/0011_001.txt
+++ b/tests/templates/0011_001.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File system traversal initiated to calculate file count and storage usage
 TESTING:Total size: \d+.*, total items: \d+, dirs: \d+, files: \d+, symlnks: \d+
 TESTING:File traversal started
@@ -94,7 +94,7 @@ TESTING:The primary database named database2.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database2.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File system traversal initiated to calculate file count and storage usage
 TESTING:Total size: \d+.*, total items: \d+, dirs: \d+, files: \d+, symlnks: \d+
 TESTING:File traversal started

--- a/tests/templates/0011_002_1.txt
+++ b/tests/templates/0011_002_1.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File system traversal initiated to calculate file count and storage usage
 TESTING:Total size: \d+.*, total items: \d+, dirs: \d+, files: \d+, symlnks: \d+
 TESTING:File traversal started

--- a/tests/templates/0011_005_1.txt
+++ b/tests/templates/0011_005_1.txt
@@ -30,7 +30,7 @@ TESTING:The primary database named %DB_NAME% is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database %DB_NAME%
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:Recursion depth limited to: \d+$
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the %DB_NAME% database:\x1B\[0m

--- a/tests/templates/0014_001_1.txt
+++ b/tests/templates/0014_001_1.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt
@@ -98,7 +98,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: tests/examples/diffs/diff1
+TESTING:Paths saved in the database:
+tests/examples/diffs/diff1
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 tests/examples/long
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_001_2.txt
+++ b/tests/templates/0014_001_2.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt
@@ -110,7 +110,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: tests/examples/long
+TESTING:Paths saved in the database:
+tests/examples/long
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 tests/examples/diffs/diff2
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_001_3.txt
+++ b/tests/templates/0014_001_3.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_001_4.txt
+++ b/tests/templates/0014_001_4.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_002_1.txt
+++ b/tests/templates/0014_002_1.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt
@@ -98,7 +98,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: /.*tests/examples/diffs/diff1
+TESTING:Paths saved in the database:
+/.*tests/examples/diffs/diff1
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 ^/.*tests/examples/long
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_002_2.txt
+++ b/tests/templates/0014_002_2.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt
@@ -110,7 +110,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: /.*/tests/examples/long
+TESTING:Paths saved in the database:
+/.*/tests/examples/long
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 ^/.*/examples/diffs/diff2
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_002_3.txt
+++ b/tests/templates/0014_002_3.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_002_4.txt
+++ b/tests/templates/0014_002_4.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_003_1.txt
+++ b/tests/templates/0014_003_1.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt
@@ -98,7 +98,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: tests/examples/diffs/diff1
+TESTING:Paths saved in the database:
+tests/examples/diffs/diff1
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 tests/examples/long
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_003_2.txt
+++ b/tests/templates/0014_003_2.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt
@@ -110,7 +110,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: tests/examples/long
+TESTING:Paths saved in the database:
+tests/examples/long
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 tests/examples/diffs/diff2
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_003_3.txt
+++ b/tests/templates/0014_003_3.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_003_4.txt
+++ b/tests/templates/0014_003_4.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_004_1.txt
+++ b/tests/templates/0014_004_1.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt
@@ -98,7 +98,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: /.*tests/examples/diffs/diff1
+TESTING:Paths saved in the database:
+/.*tests/examples/diffs/diff1
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 ^/.*tests/examples/long
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_004_2.txt
+++ b/tests/templates/0014_004_2.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt
@@ -110,7 +110,8 @@ TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
 TESTING:The database database1.db has already been created previously
 TESTING:The paths passed as arguments differ from those saved in the database. File paths and checksum information may be lost!
-TESTING:Paths saved in the database: /.*/tests/examples/long
+TESTING:Paths saved in the database:
+/.*/tests/examples/long
 TESTING:The \x1B\[1m--force\x1B\[0m option has been used, so the following paths will be written to the database1.db:
 ^/.*/examples/diffs/diff2
 TESTING:The \x1B\[1m--update\x1B\[0m option has been used, so the information about files will be updated against the database database1.db

--- a/tests/templates/0014_004_3.txt
+++ b/tests/templates/0014_004_3.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0014_004_4.txt
+++ b/tests/templates/0014_004_4.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 длинныйпутьвЮТФ8/аа…ddкрайний/path1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0015_004.txt
+++ b/tests/templates/0015_004.txt
@@ -30,7 +30,7 @@ TESTING:The primary database named %DB_NAME% is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database %DB_NAME%
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the %DB_NAME% database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0016_001_1.txt
+++ b/tests/templates/0016_001_1.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt

--- a/tests/templates/0018_001_1.txt
+++ b/tests/templates/0018_001_1.txt
@@ -33,7 +33,7 @@ TESTING:The primary database named database3.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database3.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:Recursion depth limited to: 3
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database3.db database:\x1B\[0m

--- a/tests/templates/0018_002_1.txt
+++ b/tests/templates/0018_002_1.txt
@@ -16,8 +16,10 @@
 \+TESTING:The database database3.db is on version 1 and does not require any upgrades
 -TESTING:The primary database and tables have been successfully initialized
 \+TESTING:The primary database and tables have NOT been initialized
-\+TESTING:The database database3.db has already been created previously
+-TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 -TESTING:Recursion depth limited to: 3
+\+TESTING:The database database3.db has already been created previously
+\+TESTING:The paths written against the database and the paths passed as arguments are completely identical
 \+TESTING:The \\x1B\\\[1m--update\\x1B\\\[0m option has been used, so the information about files will be updated against the database database3.db
 -TESTING:\\x1B\\\[1mThese files will be added against the database3.db database:\\x1B\\\[0m
 -1/2/3/ccc.txt

--- a/tests/templates/0019_001.txt
+++ b/tests/templates/0019_001.txt
@@ -32,7 +32,7 @@ TESTING:The primary database named database1.db is ready for operations
 TESTING:The in-memory runtime_paths_id database successfully attached to the primary database database1.db
 TESTING:Database initialization process completed
 TESTING:Database comparison mode is not enabled. Skipping comparison
-TESTING:The paths written against the database and the paths passed as arguments are completely identical
+TESTING:The brand new database has just been created. No need to verify the paths stored in the database against those passed as command-line arguments
 TESTING:File traversal started
 TESTING:\x1B\[1mThese files will be added against the database1.db database:\x1B\[0m
 1/AAA/BCB/CCC/a.txt


### PR DESCRIPTION
Even when the newest database was created, there was still a message indicating that the paths recorded in the database matched those passed as arguments.