### PR TITLE
v0.2.7

### DIFF
--- a/.github/workflows/precizer.yml
+++ b/.github/workflows/precizer.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build project
         run: |
           make portable
-          zip --junk-paths precizer precizer.v${{ env.VERSION }}
+          zip --junk-paths precizer.v${{ env.VERSION }} precizer
 
       - name: Run tests
         run: make tests-sanitize

--- a/.github/workflows/precizer.yml
+++ b/.github/workflows/precizer.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Build project
         run: |
           make portable
-          zip --junk-paths precizer.v${{ env.VERSION }} precizer
+          zip --junk-paths precizer.v${{ env.VERSION }}.zip precizer
+          ls -la
 
       - name: Run tests
         run: make tests-sanitize

--- a/.github/workflows/precizer.yml
+++ b/.github/workflows/precizer.yml
@@ -13,29 +13,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get annotated tag message
+        id: tag_message
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          echo "BODY=$(git tag -l --format='%(contents)' ${{ github.ref_name }})" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y gcc make libpcre2-dev llvm upx gh
 
       - name: Build project
         run: |
           make portable
-          zip --junk-paths precizer precizer
+          zip --junk-paths precizer precizer.v${{ env.VERSION }}
 
       - name: Run tests
         run: make tests-sanitize
 
-      - name: Get annotated tag message
-        id: tag_message
-        run: |
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          echo "BODY=$(git tag -l --format='%(contents)' ${{ github.ref_name }})" >> $GITHUB_ENV
 
       - name: Create GitHub Release with gh CLI
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} precizer.zip \
+          gh release create ${{ github.ref_name }} precizer.v${{ env.VERSION }}.zip \
             --title "v${{ github.ref_name }}" \
             --notes "${{ env.BODY }}" \
             --draft

--- a/.github/workflows/precizer.yml
+++ b/.github/workflows/precizer.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           make portable
           zip --junk-paths precizer.v${{ env.VERSION }}.zip precizer
-          ls -la
 
       - name: Run tests
         run: make tests-sanitize

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,11 @@ tests/examples/huge/
 tests/testitall
 tools/tool_*
 precizer
-*.old
+/*.old
 *~
 *.backup
-./*.db
-./*.db-shm
-./*.db-wal
-./*.out.*
+/*.db
+/*.db-shm
+/*.db-wal
+/*.out.*
+/src/tool_*

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ precizer
 /*.db-wal
 /*.out.*
 /src/tool_*
+.vms/

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ ifneq ($(CC), clang)
 WFLAGS += -Wlogical-op
 endif
 
-# Arguments for tests
+# Arguments for the test
 ARGS = --update tests/examples/diffs
 
 # Config settings:

--- a/src/add_string_to_array.c
+++ b/src/add_string_to_array.c
@@ -1,22 +1,25 @@
 #include "precizer.h"
 
 /**
- * @brief Adds a new string to a NULL-terminated array of strings
+ * @brief Adds a new string to a dynamically allocated NULL-terminated array of strings.
  *
- * @details This function adds additional strings to a dynamic
- * array of strings. The last line contains NULL. This
- * way safely loop could be used until NULL is
- * encountered.
+ * @details This function dynamically appends a string to an array of strings.
+ *          The array must be NULL-terminated to allow safe iteration.
+ *          It reallocates memory to accommodate the new entry, ensuring the array
+ *          remains NULL-terminated after adding the new string.
  *
- * @return Return SUCCESS if string was added successfully,
- *         FAILURE if memory allocation failed
+ * @param array_ptr  Pointer to the dynamic array of strings (NULL-terminated).
+ *                   The array will be reallocated to fit the new string.
+ * @param new_string The string to append to the array.
  *
- * @note The array must be NULL-terminated
+ * @return SUCCESS if the string was successfully added.
+ *         FAILURE if memory allocation fails at any point.
  *
- * @warning Freeing the memory from the string
- * array occurs in the free_config() function
- * before the app exits.
+ * @note The provided array must be initialized properly as either NULL or a valid
+ *       NULL-terminated array of strings before calling this function.
  *
+ * @warning Memory allocated by this function is freed by calling the free_config()
+ *          function upon program termination.
  */
 Return add_string_to_array(
 	char       ***array_ptr,

--- a/src/add_string_to_array.c
+++ b/src/add_string_to_array.c
@@ -26,6 +26,18 @@ Return add_string_to_array(
 	/// By default, the function worked without errors.
 	Return status = SUCCESS;
 
+	if(array_ptr == NULL)
+	{
+		report("Invalid parameter: array_ptr is NULL");
+		provide(FAILURE);
+	}
+
+	if(new_string == NULL)
+	{
+		report("Invalid parameter: new_string is NULL");
+		provide(FAILURE);
+	}
+
 	// Calculate the size of the current string array
 	size_t size = 0;
 	char **array = *array_ptr;

--- a/src/db_close.c
+++ b/src/db_close.c
@@ -6,8 +6,8 @@
  *
  */
 Return db_close(
-	sqlite3 *db,
-	bool    *db_file_modified)
+	sqlite3    *db,
+	const bool *db_file_modified)
 {
 	Return status = SUCCESS;
 

--- a/src/db_insert_the_record.c
+++ b/src/db_insert_the_record.c
@@ -33,7 +33,8 @@ Return db_insert_the_record(
 	const unsigned char  *sha512,
 	const CmpctStat      *stat,
 	const SHA512_Context *mdContext,
-	const bool           *zero_size_file)
+	const bool           *zero_size_file,
+	const bool           *wrong_file_type)
 {
 	/// The status that will be passed to return() before exiting.
 	/// By default, the function worked without errors.
@@ -96,7 +97,7 @@ Return db_insert_the_record(
 	/* Bind SHA512 checksum */
 	if(SUCCESS == status)
 	{
-		if(*offset == 0 && *zero_size_file == false)
+		if(*offset == 0 && *zero_size_file == false && *wrong_file_type == false)
 		{
 			rc = sqlite3_bind_blob(insert_stmt,3,sha512,SHA512_DIGEST_LENGTH,NULL);
 		} else {

--- a/src/db_migrate_from_0_to_1.c
+++ b/src/db_migrate_from_0_to_1.c
@@ -254,11 +254,8 @@ Return db_migrate_from_0_to_1(const char *db_file_path)
 				config->db_primary_file_modified = true;
 			}
 		}
-	}
 
-	/* Cleanup */
-	if(SUCCESS == status)
-	{
+		/* Cleanup */
 		status = db_close(db,&db_file_modified);
 	}
 

--- a/src/db_migrate_from_1_to_2.c
+++ b/src/db_migrate_from_1_to_2.c
@@ -66,11 +66,7 @@ Return db_migrate_from_1_to_2(const char *db_file_path)
 			config->db_primary_file_modified = true;
 		}
 
-	}
-
-	/* Cleanup */
-	if(SUCCESS == status)
-	{
+		/* Cleanup */
 		status = db_close(db,&config->db_primary_file_modified);
 	}
 

--- a/src/db_update_the_record_by_id.c
+++ b/src/db_update_the_record_by_id.c
@@ -23,7 +23,8 @@ Return db_update_the_record_by_id(
 	const unsigned char  *sha512,
 	const CmpctStat      *stat,
 	const SHA512_Context *mdContext,
-	const bool           *zero_size_file)
+	const bool           *zero_size_file,
+	const bool           *wrong_file_type)
 {
 	/// The status that will be passed to return() before exiting.
 	/// By default, the function worked without errors.
@@ -81,7 +82,7 @@ Return db_update_the_record_by_id(
 	/* Bind SHA512 checksum */
 	if(SUCCESS == status)
 	{
-		if(*offset == 0 && *zero_size_file == false)
+		if(*offset == 0 && *zero_size_file == false && *wrong_file_type == false)
 		{
 			rc = sqlite3_bind_blob(update_stmt,2,sha512,SHA512_DIGEST_LENGTH,NULL);
 		} else {

--- a/src/db_vacuum.c
+++ b/src/db_vacuum.c
@@ -95,11 +95,8 @@ Return db_vacuum(const char *db_file_path)
 			   this in the global variable value. */
 			config->db_primary_file_modified = true;
 		}
-	}
 
-	/* Cleanup */
-	if(SUCCESS == status)
-	{
+		/* Cleanup */
 		status = db_close(db,&db_file_modified);
 	}
 

--- a/src/file_list.c
+++ b/src/file_list.c
@@ -359,6 +359,18 @@ Return file_list(const bool count_size_of_all_files)
 
 				bool zero_size_file = false;
 
+				/**
+				 * On some special file systems (such as /sys, which has
+				 * the SYSFS_MAGIC constant == 0x62656572), standard
+				 * file operations like fopen, fseek, and lseek
+				 * cannot be used for reading and seeking.
+				 * While information about the file itself will be
+				 * recorded in the primary database, due to the
+				 * nature of such files, their hash sum is never
+				 * read and is stored as NULL
+				 */
+				bool wrong_file_type = false;
+
 				if(p->fts_statp->st_size == 0)
 				{
 					zero_size_file = true;
@@ -394,7 +406,7 @@ Return file_list(const bool count_size_of_all_files)
 				{
 					if(SUCCESS == status)
 					{
-						status = sha512sum(p->fts_path,&p->fts_pathlen,sha512,&offset,&mdContext);
+						status = sha512sum(p->fts_path,&p->fts_pathlen,sha512,&offset,&mdContext,&wrong_file_type);
 
 						if(SUCCESS == status)
 						{
@@ -435,7 +447,7 @@ Return file_list(const bool count_size_of_all_files)
 					/* Update record in DB */
 					if(SUCCESS == status)
 					{
-						status = db_update_the_record_by_id(&(dbrow->ID),&offset,sha512,&stat,&mdContext,&zero_size_file);
+						status = db_update_the_record_by_id(&(dbrow->ID),&offset,sha512,&stat,&mdContext,&zero_size_file,&wrong_file_type);
 
 						if(SUCCESS != status)
 						{
@@ -449,9 +461,9 @@ Return file_list(const bool count_size_of_all_files)
 					if(SUCCESS == status)
 					{
 #if 0 // Old multiPATH solution
-						status = db_insert_the_record(&path_prefix_index,relative_path,&offset,sha512,&stat,&mdContext);
+						status = db_insert_the_record(&path_prefix_index,relative_path,&offset,sha512,&stat,&mdContext,&zero_size_file,&wrong_file_type);
 #else
-						status = db_insert_the_record(relative_path,&offset,sha512,&stat,&mdContext,&zero_size_file);
+						status = db_insert_the_record(relative_path,&offset,sha512,&stat,&mdContext,&zero_size_file,&wrong_file_type);
 #endif
 
 						if(SUCCESS != status)

--- a/src/precizer.h
+++ b/src/precizer.h
@@ -440,7 +440,7 @@ Return init_signals(void);
 
 Return db_close(
 	sqlite3 *,
-	bool *);
+	const bool *);
 
 void db_primary_sync(void);
 

--- a/src/precizer.h
+++ b/src/precizer.h
@@ -408,7 +408,8 @@ Return sha512sum(
 	const short unsigned int *,
 	unsigned char *,
 	sqlite3_int64 *,
-	SHA512_Context *);
+	SHA512_Context *,
+	bool *);
 
 Return add_string_to_array(
 	char ***,
@@ -470,6 +471,7 @@ Return db_update_the_record_by_id(
 	const unsigned char *,
 	const CmpctStat *,
 	const SHA512_Context *,
+	const bool *,
 	const bool *);
 
 Return db_insert_the_record(
@@ -478,6 +480,7 @@ Return db_insert_the_record(
 	const unsigned char *,
 	const CmpctStat *,
 	const SHA512_Context *,
+	const bool *,
 	const bool *);
 
 Return db_determine_name(void);

--- a/src/sha512sum.c
+++ b/src/sha512sum.c
@@ -40,7 +40,8 @@ Return sha512sum(
 	const short unsigned int *path_size,
 	unsigned char            *sha512,
 	sqlite3_int64            *offset,
-	SHA512_Context           *mdContext)
+	SHA512_Context           *mdContext,
+	bool                     *wrong_file_type)
 {
 	/// The status that will be passed to return() before exiting.
 	/// By default, the function worked without errors.
@@ -115,11 +116,11 @@ Return sha512sum(
 	// It moves the file pointer "offset" bytes from the beginning of the file
 	if(fseek(fileptr,*offset,SEEK_SET) != 0)
 	{
-		slog(ERROR,"Failed to seek to offset %lld in file %s\n",*offset,path);
+		// Looks like the wrong file type
+		*wrong_file_type = true;
 		free(buffer);
 		free(absolute_path);
 		fclose(fileptr);
-		status = FAILURE;
 		provide(status);
 	}
 


### PR DESCRIPTION
# Release version v0.2.7
## Added the ability to handle files on special file systems without triggering an error message
On some special file systems (such as /sys, which has the SYSFS_MAGIC constant == 0x62656572), standard file operations like fopen, fseek, and lseek cannot be used for reading and seeking. While information about the file itself will be recorded in the primary database, due to the nature of such files, their hash sum is never read and is stored as NULL.