### PR TITLE
Fix unsafe operations in signal handler

### DIFF
--- a/src/notify_quit_handler.c
+++ b/src/notify_quit_handler.c
@@ -9,27 +9,28 @@
  */
 void notify_quit_handler(int sig)
 {
-	printf("Notify quit!\n");
+        /*
+         * Only async-signal-safe operations are allowed inside
+         * the signal handler.  Using printf() or other stdio
+         * functions may lead to undefined behaviour and could
+         * interrupt the graceful shutdown procedure.
+         */
 
-	atomic_store(&global_interrupt_flag,true);
+        atomic_store(&global_interrupt_flag,true);
+        atomic_store(&global_return_status,HALTED);
 
-	atomic_store(&global_return_status,HALTED);
+        const char msg_term[] =
+                "Terminating the application. Please wait while the database will be closed smoothly…\n";
+        const char msg_int[] =
+                "Interrupting the application. Please wait while the database will be closed smoothly…\n";
 
-	printf("The global return status and exit flag has been set to %s\n",show_status(global_return_status));
+        if(sig==SIGTERM)
+        {
+                (void)write(STDOUT_FILENO,msg_term,sizeof(msg_term)-1);
+        }
 
-	if(sig==SIGTERM)
-	{
-		printf("Terminating the application. Please wait while the database will be closed smoothly…\n");
-	}
-
-	if(sig==SIGINT)
-	{
-		printf("Interrupting the application. Please wait while the database will be closed smoothly…\n");
-	}
-
-	/// Enable key echo in terminal
-	struct termios term;
-	tcgetattr(fileno(stdin),&term);
-	term.c_lflag |= (ICANON|ECHO);
-	tcsetattr(fileno(stdin),0,&term);
+        if(sig==SIGINT)
+        {
+                (void)write(STDOUT_FILENO,msg_int,sizeof(msg_int)-1);
+        }
 }


### PR DESCRIPTION
## Summary
- avoid calling non-async-signal-safe functions from `notify_quit_handler`
- use `write` to display shutdown messages

## Testing
- `make tests` *(fails: pcre2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684738f9464c832ca3a578e630b80672