### PR TITLE
Publish Pages site to user domain

### DIFF
--- a/.github/workflows/publish-user-site.yml
+++ b/.github/workflows/publish-user-site.yml
@@ -1,0 +1,37 @@
+name: Publish user GitHub Pages site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy-user-site:
+    name: Sync site to precizer.github.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare Pages content
+        run: |
+          rm -rf site
+          mkdir -p site
+          cp _config.yml site/
+          cp README.md site/
+          cp README.ru.md site/
+          cp -r img site/
+
+      - name: Publish to precizer.github.io
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          external_repository: precizer/precizer.github.io
+          publish_branch: main
+          publish_dir: site
+          publish_commit_message: "chore: update user pages from precizer"
+          deploy_key: ${{ secrets.USER_SITE_DEPLOY_KEY }}

--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,5 @@ title: Precizer
 description: precizer is a CLI application for verifying file integrity after synchronization. The program recursively traverses directories, creates a database of files with their checksums, and performs comparisons.
 show_downloads: false
 theme: jekyll-theme-cayman
+url: https://precizer.github.io
+baseurl: ""

--- a/tools/pages-deployment.md
+++ b/tools/pages-deployment.md
@@ -1,0 +1,13 @@
+# Публикация сайта на https://precizer.github.io/
+
+Этот репозиторий теперь может автоматически синхронизировать содержимое Jekyll-сайта в репозиторий **precizer/precizer.github.io**, чтобы страница открывалась по адресу `https://precizer.github.io/` без суффикса `/precizer/`.
+
+## Подготовка одноимённого репозитория
+1. Создайте (или переименуйте существующий) репозиторий `precizer.github.io` в организации/аккаунте `precizer`.
+2. Включите GitHub Pages для ветки `main` и корня репозитория.
+
+## Настройка секрета для деплоя
+В репозитории `precizer` создайте секрет `USER_SITE_DEPLOY_KEY` с деплой-ключом, который имеет права записи в `precizer/precizer.github.io` (см. [Deploy keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys)).
+
+## Запуск публикации
+После пуша в `main` или ручного запуска workflow `Publish user GitHub Pages site` содержимое `_config.yml`, `README.md`, `README.ru.md` и каталога `img` будет скопировано в ветку `main` репозитория `precizer.github.io`.


### PR DESCRIPTION
## Summary
- configure the Jekyll site for hosting at https://precizer.github.io/
- add a workflow that syncs site assets to the precizer.github.io repository
- document how to set up the deploy key and target repository for the new user-site deployment

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c42eb6520832c8be6c6a70deb2a94)