### PR TITLE
Abort legacy DB migrations on incompatible stat blobs

### DIFF
--- a/src/db_migrate_from_0_to_1.c
+++ b/src/db_migrate_from_0_to_1.c
@@ -99,8 +99,7 @@ static Return populate_from_glibc_stat_blob(
 /**
  * @brief Convert and rewrite one row of the files table.
  *
- * Invalid legacy blobs are replaced with a zeroed CmpctStat_v1 and migration
- * continues; FAILURE is returned only for SQLite errors.
+ * Invalid legacy blobs are fatal and abort migration.
  *
  * @param[in] stmt Prepared statement positioned at the current row.
  * @param[out] db_file_modified Set to true when row update succeeds.
@@ -133,8 +132,8 @@ static Return process_row(
 
 	if(SUCCESS != conversion_status)
 	{
-		memset(&new_stat,0,sizeof(new_stat));
-		slog(ERROR,"Invalid legacy stat blob for row id=%lld (len=%d). Zero v1 stat will be stored\n",(long long)row_id,blob_size);
+		slog(ERROR,"Invalid legacy stat blob for row id=%lld (len=%d). Aborting migration to avoid metadata loss\n",(long long)row_id,blob_size);
+		status = FAILURE;
 	}
 
 	/* Prepare update statement */
@@ -182,8 +181,8 @@ static Return process_row(
 /**
  * @brief Process all rows of the files table for v0->v1 conversion.
  *
- * Row-level data corruption does not stop migration. The function fails only on
- * SQLite iteration/update errors or external interruption.
+ * Row-level data corruption stops migration. The function also fails on SQLite
+ * iteration/update errors or external interruption.
  *
  * @param[in] db Open SQLite handle.
  * @param[out] db_file_modified Set to true when at least one row is updated.

--- a/src/db_migrate_to_version_4.c
+++ b/src/db_migrate_to_version_4.c
@@ -11,8 +11,7 @@
 /**
  * @brief Convert CmpctStat_v1 into CmpctStat (v4 layout).
  *
- * Caller may pass a zero-initialized source for corrupted rows; in that case
- * the destination remains a valid zeroed v4 record.
+ * Source data must be a validated v3 compact stat blob.
  */
 static void convert_blob_to_v4_stat(
 	const CmpctStat_v1 *source,
@@ -33,8 +32,7 @@ static void convert_blob_to_v4_stat(
 /**
  * @brief Migrate one files row to v4 stat format.
  *
- * Row with invalid blob size/content is not fatal: a zeroed source is used and
- * a zeroed v4 stat is written. FAILURE is returned only for SQLite errors.
+ * Row with invalid blob size/content is fatal and aborts migration.
  */
 static Return process_row(
 	sqlite3_stmt *stmt,
@@ -58,14 +56,20 @@ static Return process_row(
 		{
 			source = blob;
 		} else {
-			slog(ERROR,"Invalid v3 stat blob pointer for row id=%lld (size=%d). Zero stat will be stored\n",(long long)row_id,blob_size);
+			slog(ERROR,"Invalid v3 stat blob pointer for row id=%lld (size=%d). Aborting migration to avoid metadata loss\n",(long long)row_id,blob_size);
+			status = FAILURE;
 		}
 	} else {
-		slog(ERROR,"Invalid v3 stat blob size for row id=%lld (got=%d, expected=%zu). Zero stat will be stored\n",(long long)row_id,blob_size,sizeof(CmpctStat_v1));
+		slog(ERROR,"Invalid v3 stat blob size for row id=%lld (got=%d, expected=%zu). Aborting migration to avoid metadata loss\n",(long long)row_id,blob_size,sizeof(CmpctStat_v1));
+		status = FAILURE;
 	}
 
 	CmpctStat destination = {0};
-	convert_blob_to_v4_stat(source,&destination);
+
+	if(SUCCESS == status)
+	{
+		convert_blob_to_v4_stat(source,&destination);
+	}
 
 	sqlite3_stmt *update_stmt = NULL;
 	const char *update_sql = "UPDATE files SET stat = ?1 WHERE ID = ?2";
@@ -124,8 +128,8 @@ static Return process_row(
 /**
  * @brief Convert all files.stat blobs to v4 format.
  *
- * Corrupted row payloads do not stop migration; iteration stops only on SQLite
- * errors or external interruption.
+ * Corrupted row payloads stop migration to avoid data loss; iteration also
+ * stops on SQLite errors or external interruption.
  */
 static Return process_database(
 	sqlite3 *db,


### PR DESCRIPTION
### Motivation
- Prevent silent metadata loss by restoring fail-fast behavior when legacy `stat` blobs are incompatible or undecodable. 
- Fix two P1 issues discovered during review: v1–v3→v4 migration rewriting rows on `sizeof` mismatch, and v0→v1 migration continuing after `populate_from_glibc_stat_blob` failures.

### Description
- In `src/db_migrate_to_version_4.c` treat an unexpected `stat` blob size or a NULL blob pointer as a hard failure, set `status = FAILURE`, and skip conversion/update unless validation succeeds. 
- In `src/db_migrate_from_0_to_1.c` treat `populate_from_glibc_stat_blob` decode failure as fatal by setting `status = FAILURE` and removing the previous zeroing-and-continue fallback. 
- Updated comments and error log messages to clearly indicate abort-on-corruption semantics and to warn about metadata-loss prevention. 
- Conversion and update steps are only executed when the per-row validation returns `SUCCESS` so the surrounding migration transaction can roll back on error.

### Testing
- Ran `make -j4` to validate the change; the build could not complete in this environment due to a missing dependency header (`pcre2.h`), so a full compile/test run was not possible. 
- Verified the code changes with local textual/diff inspection to ensure the new fail-fast control flow and log messages are present in `src/db_migrate_to_version_4.c` and `src/db_migrate_from_0_to_1.c`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e413e1614832cafa0c4a9fa2f5fcd)