### PR TITLE
Sanitize unsafe terminal bytes in logger output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes will be documented in this file
 
+# Release 0.15.1 2026-06-07
+
+## Fixed
+
+- Fixed a terminal output issue where rare file names containing control characters could make later scan messages disappear from the screen. Such bytes are now printed as readable `\xNN` escapes, while normal Unicode file names remain readable
+
 # Release 0.15.0 2026-06-06
 
 ## Fixed

--- a/libs/rational/src/rational_logger.c
+++ b/libs/rational/src/rational_logger.c
@@ -1,4 +1,6 @@
 #include "rational.h"
+#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -182,6 +184,338 @@ static void logger_line_append(
 	va_end(args);
 }
 
+/**
+ * @brief Append one byte as a visible hexadecimal escape
+ *
+ * @param[in,out] line Destination buffer with enough free space
+ * @param[in,out] line_len Current destination length in bytes
+ * @param[in] byte Byte to append as \xNN
+ */
+static void logger_line_append_hex_escape(
+	char          *line,
+	size_t        *line_len,
+	unsigned char byte)
+{
+	/*
+	 * Use an explicit digit table instead of sprintf().
+	 * This helper is used from the logger cleanup path, so it should not depend
+	 * on formatting functions or temporary buffers just to render one byte
+	 */
+	static const char hex_digits[] = "0123456789ABCDEF";
+
+	/*
+	 * Write the escape directly into the caller-owned output buffer.
+	 * The sanitizer allocates enough room before calling this helper, and
+	 * line_len is advanced after every written character so the next append can
+	 * continue from the correct position
+	 */
+	line[(*line_len)++] = '\\';
+	line[(*line_len)++] = 'x';
+	line[(*line_len)++] = hex_digits[byte >> 4U];
+	line[(*line_len)++] = hex_digits[byte & 0x0FU];
+}
+
+/**
+ * @brief Decode one UTF-8 sequence from a bounded byte range
+ *
+ * @details
+ * The logger uses this small decoder instead of locale-dependent multibyte
+ * conversion because the process locale is not guaranteed to be initialized
+ * before a log line is printed. The function accepts only shortest-form UTF-8,
+ * rejects surrogate code points, and rejects values outside the Unicode range
+ *
+ * @param[in] line Source byte range
+ * @param[in] line_len Number of bytes available at @p line
+ * @param[out] codepoint Decoded Unicode code point
+ * @return Number of bytes consumed, or 0 when the input is not valid UTF-8
+ */
+static size_t logger_line_decode_utf8(
+	const char *line,
+	size_t     line_len,
+	uint32_t   *codepoint)
+{
+	/*
+	 * Refuse invalid input before looking at the first byte.
+	 * Returning 0 tells the caller to treat the current byte as unsafe and
+	 * print it as a visible escape instead of trusting it as text
+	 */
+	if(line == NULL || codepoint == NULL || line_len == 0U)
+	{
+		return(0U);
+	}
+
+	const unsigned char first_byte = (unsigned char)line[0];
+
+	/*
+	 * ASCII is a single-byte subset of UTF-8.
+	 * Decoding it here keeps the rest of the function focused on multibyte
+	 * sequences and lets the caller apply its own ASCII control-character policy
+	 */
+	if(first_byte < 0x80U)
+	{
+		*codepoint = (uint32_t)first_byte;
+		return(1U);
+	}
+
+	/*
+	 * Classify the leading byte and prepare the partial code point.
+	 * The first byte tells us how many continuation bytes must follow and also
+	 * provides the high bits of the decoded Unicode value
+	 */
+	size_t expected_len = 0U;
+	uint32_t decoded_codepoint = 0U;
+	uint32_t lowest_codepoint = 0U;
+
+	if(first_byte >= 0xC2U && first_byte <= 0xDFU)
+	{
+		expected_len = 2U;
+		decoded_codepoint = (uint32_t)(first_byte & 0x1FU);
+		lowest_codepoint = 0x80U;
+	} else if(first_byte >= 0xE0U && first_byte <= 0xEFU){
+		expected_len = 3U;
+		decoded_codepoint = (uint32_t)(first_byte & 0x0FU);
+		lowest_codepoint = 0x800U;
+	} else if(first_byte >= 0xF0U && first_byte <= 0xF4U){
+		expected_len = 4U;
+		decoded_codepoint = (uint32_t)(first_byte & 0x07U);
+		lowest_codepoint = 0x10000U;
+	} else {
+		/*
+		 * Bytes outside these leading-byte ranges cannot start a valid UTF-8
+		 * sequence. This includes continuation bytes seen without a starter,
+		 * obsolete overlong starters, and values beyond the Unicode limit
+		 */
+		return(0U);
+	}
+
+	/*
+	 * A valid sequence must be complete inside the provided byte range.
+	 * The logger works with bounded buffers, so an incomplete trailing sequence
+	 * is escaped byte by byte rather than reading past the formatted line
+	 */
+	if(line_len < expected_len)
+	{
+		return(0U);
+	}
+
+	/*
+	 * Every byte after the leading byte must have the UTF-8 continuation shape
+	 * 10xxxxxx. While checking that shape, assemble the final code point by
+	 * shifting in the six payload bits carried by each continuation byte
+	 */
+	for(size_t i = 1U; i < expected_len; i++)
+	{
+		const unsigned char continuation_byte = (unsigned char)line[i];
+
+		if((continuation_byte & 0xC0U) != 0x80U)
+		{
+			return(0U);
+		}
+
+		decoded_codepoint = (decoded_codepoint << 6U) | (uint32_t)(continuation_byte & 0x3FU);
+	}
+
+	/*
+	 * Reject overlong encodings.
+	 * UTF-8 has exactly one shortest byte representation for each code point,
+	 * and accepting longer aliases would let unsafe bytes hide behind another
+	 * spelling of the same character
+	 */
+	if(decoded_codepoint < lowest_codepoint)
+	{
+		return(0U);
+	}
+
+	/*
+	 * UTF-16 surrogate values are not Unicode scalar values.
+	 * They are invalid in UTF-8 text, so the logger escapes their original bytes
+	 * instead of copying them into terminal output
+	 */
+	if(decoded_codepoint >= 0xD800U && decoded_codepoint <= 0xDFFFU)
+	{
+		return(0U);
+	}
+
+	/*
+	 * Unicode ends at U+10FFFF.
+	 * Anything above that value is invalid input and must be shown as escaped
+	 * bytes, not as trusted text
+	 */
+	if(decoded_codepoint > 0x10FFFFU)
+	{
+		return(0U);
+	}
+
+	/*
+	 * At this point the byte sequence is well-formed UTF-8.
+	 * Return both the decoded code point and the number of bytes consumed so the
+	 * sanitizer can decide whether the character is safe to copy
+	 */
+	*codepoint = decoded_codepoint;
+	return(expected_len);
+}
+
+/**
+ * @brief Escape bytes that can disrupt terminal output
+ *
+ * @details
+ * The logger receives an already formatted line, so this layer cannot tell
+ * whether bytes came from a file name, a database path, an error message, or
+ * fixed application text. The filter therefore treats the complete log line as
+ * terminal output and escapes only byte patterns that are unsafe to write as
+ * text. Plain printable ASCII, newline, carriage return, tab, raw ESC, and
+ * valid non-C1 UTF-8 multibyte sequences are preserved. Invalid multibyte input
+ * is escaped byte by byte so malformed file names remain visible without being
+ * interpreted by the terminal. Unicode C1 control characters such as U+0090
+ * are also escaped, even though their UTF-8 byte sequence is formally valid,
+ * because terminals may interpret them as control strings and hide later output.
+ *
+ * This first pass deliberately leaves raw ESC bytes unchanged. The project uses
+ * ESC-based decorations such as bold and colors, and distinguishing those
+ * trusted decorations from path bytes requires a separate whitelist policy. That
+ * whitelist can be added later without changing slog() call sites
+ *
+ * @param[in,out] line Pointer to the allocated line buffer
+ * @param[in,out] line_len Current line length in bytes, updated on success
+ */
+static void logger_line_sanitize_for_terminal(
+	char **line,
+	int  *line_len)
+{
+	/*
+	 * Nothing useful can be sanitized without an existing allocated buffer and a
+	 * positive byte count. Returning quietly preserves the logger's current
+	 * best-effort behavior for allocation and formatting failure paths
+	 */
+	if(line == NULL || *line == NULL || line_len == NULL || *line_len <= 0)
+	{
+		return;
+	}
+
+	const size_t input_len = (size_t)*line_len;
+
+	/*
+	 * Escaping one input byte as \xNN needs four output bytes.
+	 * This guard keeps the worst-case allocation and the final int length update
+	 * inside representable bounds
+	 */
+	if(input_len > (size_t)INT_MAX / 4U)
+	{
+		return;
+	}
+
+	/*
+	 * Allocate for the worst case where every input byte becomes \xNN.
+	 * The extra byte is for a terminator because the logger stores text in a C
+	 * string buffer even though fwrite() uses the explicit byte length
+	 */
+	char *sanitized_line = malloc((input_len * 4U) + 1U);
+
+	if(sanitized_line == NULL)
+	{
+		return;
+	}
+
+	/*
+	 * input_position walks through the original formatted line.
+	 * output_len tracks the next free position in the sanitized replacement
+	 * buffer, which may grow faster than the input when bytes are escaped
+	 */
+	size_t input_position = 0U;
+	size_t output_len = 0U;
+
+	/*
+	 * Consume one ASCII byte or one complete UTF-8 sequence per loop.
+	 * The loop never trusts a multibyte sequence until it has been decoded and
+	 * checked, so damaged input cannot leak raw terminal controls into output
+	 */
+	while(input_position < input_len)
+	{
+		const unsigned char byte = (unsigned char)(*line)[input_position];
+
+		if(byte < 0x80U)
+		{
+			/*
+			 * ASCII printable characters are safe to copy.
+			 * Newline, carriage return, and tab are preserved because log lines
+			 * legitimately use them for layout. ESC is also preserved for now so
+			 * existing color and bold decorations keep working until an explicit
+			 * decoration whitelist is added
+			 */
+			if(byte == '\n' || byte == '\r' || byte == '\t' || byte == '\033' || (byte >= 0x20U && byte != 0x7FU))
+			{
+				sanitized_line[output_len++] = (char)byte;
+			} else {
+				/*
+				 * Other ASCII control bytes and DEL are not safe terminal text.
+				 * Showing them as \xNN makes the byte visible to the user while
+				 * preventing the terminal from treating it as an action
+				 */
+				logger_line_append_hex_escape(sanitized_line,&output_len,byte);
+			}
+
+			input_position++;
+			continue;
+		}
+
+		/*
+		 * Non-ASCII input must first prove that it is valid UTF-8.
+		 * The decoder is intentionally local and locale-independent so logger
+		 * safety does not depend on whether setlocale() has already run
+		 */
+		uint32_t codepoint = 0U;
+		const size_t decoded_len = logger_line_decode_utf8(*line + input_position,
+			input_len - input_position,
+			&codepoint);
+
+		/*
+		 * Invalid UTF-8 is escaped one byte at a time.
+		 * This preserves every original byte in a readable form and then retries
+		 * from the next byte, which helps recover cleanly after a malformed prefix
+		 */
+		if(decoded_len == 0U)
+		{
+			logger_line_append_hex_escape(sanitized_line,&output_len,byte);
+			input_position++;
+			continue;
+		}
+
+		/*
+		 * C1 controls are dangerous even when encoded as valid UTF-8.
+		 * U+0090, for example, is a terminal control-string introducer on some
+		 * terminals, so the original bytes are escaped instead of being copied
+		 */
+		if(codepoint >= 0x80U && codepoint <= 0x9FU)
+		{
+			for(size_t i = 0U; i < decoded_len; i++)
+			{
+				const unsigned char control_byte = (unsigned char)(*line)[input_position + i];
+				logger_line_append_hex_escape(sanitized_line,&output_len,control_byte);
+			}
+		} else {
+			/*
+			 * Valid non-C1 UTF-8 is copied unchanged.
+			 * This keeps ordinary international file names and messages readable
+			 * instead of turning every non-ASCII character into escapes
+			 */
+			memcpy(sanitized_line + output_len,*line + input_position,decoded_len);
+			output_len += decoded_len;
+		}
+
+		input_position += decoded_len;
+	}
+
+	/*
+	 * Replace the original formatted line with the sanitized version.
+	 * The caller will pass the same buffer to REMEMBER and fwrite(), so both
+	 * delayed warnings and immediate terminal output see identical safe text
+	 */
+	sanitized_line[output_len] = '\0';
+	free(*line);
+	*line = sanitized_line;
+	*line_len = (int)output_len;
+}
+
 __attribute__((format(printf,7,0)))
 static void logger_line(
 	char              **line,
@@ -282,6 +616,13 @@ void rational_logger(
 	va_start(args,fmt);
 	logger_line(&logger_line_text,&line_len,level,filename,line,funcname,fmt,args);
 	va_end(args);
+
+	/*
+	 * Sanitize the final formatted line before any consumer sees it.
+	 * This keeps immediate terminal output and delayed REMEMBER output identical,
+	 * and prevents path bytes from being interpreted as terminal controls
+	 */
+	logger_line_sanitize_for_terminal(&logger_line_text,&line_len);
 
 	if((level & REMEMBER) && rational_remember && logger_line_text != NULL && line_len > 0)
 	{

--- a/libs/rational/tests/src/test_librational_0004.c
+++ b/libs/rational/tests/src/test_librational_0004.c
@@ -430,6 +430,44 @@ static Return capture_librational_slog_test(void)
 }
 
 /**
+ * @brief Capture a log line that contains unsafe terminal bytes
+ */
+static void librational_logger_terminal_safety_case(void)
+{
+	/*
+	 * The payload mixes terminal-hostile bytes with ordinary UTF-8 text.
+	 * It deliberately keeps raw ESC because this first sanitizer pass preserves
+	 * existing logger decorations until an explicit decoration whitelist exists
+	 */
+	static const char payload[] =
+	        "ascii"
+	        "\001"
+	        "del"
+	        "\177"
+	        "c1"
+	        "\302\220"
+	        "invalid"
+	        "\303("
+	        "overlong"
+	        "\300\257"
+	        "keep"
+	        "\t\r\n"
+	        "esc"
+	        "\033[1m"
+	        "utf8"
+	        "°"
+	        "à"
+	        "Привет"
+	        "天地玄黄宇宙洪荒日月盈昃辰宿列張"
+	        "いろはにほへとちりぬるを"
+	        "日本語漢字仮名交じり文";
+
+	rational_logger_mode = REGULAR;
+	slog(REGULAR|UNDECOR,"%s",payload);
+	rational_logger_mode = REGULAR;
+}
+
+/**
  * @brief Capture one serp() stderr message
  *
  * @return Return describing success or failure
@@ -777,6 +815,55 @@ static Return test_librational_0004_14(void)
 #endif
 
 /**
+ * @brief Check that slog() escapes terminal-hostile text without damaging normal UTF-8
+ *
+ * @return Return describing success or failure
+ */
+static Return test_librational_0004_15(void)
+{
+	INITTEST;
+
+	m_create(char,captured_stdout,MEMORY_STRING);
+	m_create(char,captured_stderr,MEMORY_STRING);
+
+	static const char expected_stdout[] =
+	        "ascii"
+	        "\\x01"
+	        "del"
+	        "\\x7F"
+	        "c1"
+	        "\\xC2\\x90"
+	        "invalid"
+	        "\\xC3("
+	        "overlong"
+	        "\\xC0\\xAF"
+	        "keep"
+	        "\t\r\n"
+	        "esc"
+	        "\033[1m"
+	        "utf8"
+	        "°"
+	        "à"
+	        "Привет"
+	        "天地玄黄宇宙洪荒日月盈昃辰宿列張"
+	        "いろはにほへとちりぬるを"
+	        "日本語漢字仮名交じり文";
+
+	ASSERT(SUCCESS == function_capture(
+		librational_logger_terminal_safety_case,
+		captured_stdout,
+		captured_stderr));
+
+	ASSERT(0 == strcmp(m_text(captured_stdout),expected_stdout));
+	ASSERT(captured_stderr->length == 0U);
+
+	call(m_del(captured_stdout));
+	call(m_del(captured_stderr));
+
+	RETURN_STATUS;
+}
+
+/**
  * @brief Check that function_capture() flushes pending stdout before redirection
  *
  * @return Return describing success or failure
@@ -868,9 +955,10 @@ Return test_librational_0004(void)
 	TEST(test_librational_0004_12,"slog() stays silent when vsnprintf fails");
 #endif
 	TEST(test_librational_0004_13,"slog(ERROR) stays silent when no mode accepts ERROR");
-#ifndef EVIL_EMPIRE_OS
+	#ifndef EVIL_EMPIRE_OS
 	TEST(test_librational_0004_14,"slog(REMEMBER) skips empty or unformatted payloads");
-#endif
+	#endif
+	TEST(test_librational_0004_15,"slog() escapes unsafe terminal bytes while preserving normal UTF-8");
 
 	RETURN_STATUS;
 }

--- a/libs/rational/tests/src/test_librational_0004.c
+++ b/libs/rational/tests/src/test_librational_0004.c
@@ -955,9 +955,9 @@ Return test_librational_0004(void)
 	TEST(test_librational_0004_12,"slog() stays silent when vsnprintf fails");
 #endif
 	TEST(test_librational_0004_13,"slog(ERROR) stays silent when no mode accepts ERROR");
-	#ifndef EVIL_EMPIRE_OS
+#ifndef EVIL_EMPIRE_OS
 	TEST(test_librational_0004_14,"slog(REMEMBER) skips empty or unformatted payloads");
-	#endif
+#endif
 	TEST(test_librational_0004_15,"slog() escapes unsafe terminal bytes while preserving normal UTF-8");
 
 	RETURN_STATUS;

--- a/src/version.h
+++ b/src/version.h
@@ -3,5 +3,5 @@
  *
  */
 #define APP_NAME "precizer"
-#define APP_VERSION "0.15.0"
+#define APP_VERSION "0.15.1"
 #define CURRENT_DB_VERSION 4


### PR DESCRIPTION
Some file names can contain valid UTF-8 control characters such as U+0090 (encoded as C2 90). When such bytes are written to a terminal unchanged, the terminal may treat them as control strings and stop displaying subsequent log output even though file processing continues.

Sanitize formatted slog() output before it is printed or remembered. The logger now escapes unsafe C0/C1 controls, DEL, and invalid UTF-8 bytes as visible \xNN sequences while preserving normal UTF-8 text and the existing raw ESC-based decorations for now.

Add a librational regression test covering C1 controls, malformed UTF-8, preserved layout characters, raw ESC passthrough, and ordinary Unicode text.